### PR TITLE
Add dataset generation utilities

### DIFF
--- a/data/generate_all_datasets.py
+++ b/data/generate_all_datasets.py
@@ -1,0 +1,25 @@
+import argparse
+from generate_sft_verl import main as generate_sft
+from generate_train_agentgym_all import main as generate_rl
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate datasets for SFT and GRPO/PPO training")
+    parser.add_argument('--sft_output_dir', required=True,
+                        help='Directory for the SFT dataset')
+    parser.add_argument('--rl_output_dir', required=True,
+                        help='Base directory for RL datasets (one subdir per env)')
+    parser.add_argument('--sft_valid_ratio', type=float, default=0.1,
+                        help='Validation ratio for the SFT dataset')
+    args = parser.parse_args()
+
+    print('Generating SFT dataset...')
+    generate_sft(args.sft_output_dir, args.sft_valid_ratio)
+
+    print('\nGenerating RL dataset...')
+    generate_rl(args.rl_output_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/generate_sft_verl.py
+++ b/data/generate_sft_verl.py
@@ -23,44 +23,55 @@ def make_map_fn(split):
     return process_fn
 
 
+def main(output_dir: str, valid_ratio: float = 0.1):
+    """Generate SFT dataset and save it to ``output_dir``.
+
+    Parameters
+    ----------
+    output_dir: str
+        Directory to save ``train.parquet`` and ``valid.parquet``.
+    valid_ratio: float, optional
+        Fraction of the dataset to use as validation. Default ``0.1``.
+    """
+    print(f"Loading dataset...")
+    # Load from Hugging Face Hub - full dataset
+    dataset = load_dataset("CharlieDreemur/OpenManus-RL", split="train")
+
+    print(f"Splitting dataset into train/valid with {valid_ratio*100}% validation...")
+    # Split into train and validation
+    splits = dataset.train_test_split(test_size=valid_ratio, seed=42)
+    train_dataset = splits["train"]
+    valid_dataset = splits["test"]  # The test_split method names the second split "test"
+
+    print(f"Train set: {len(train_dataset)} examples")
+    print(f"Validation set: {len(valid_dataset)} examples")
+
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Process and save train set
+    print("Processing train set...")
+    processed_train = train_dataset.map(function=make_map_fn("train"), with_indices=True)
+    train_path = os.path.join(output_dir, "train.parquet")
+    processed_train.to_parquet(train_path)
+    print(f"Saved train set to {train_path}")
+
+    # Process and save validation set
+    print("Processing validation set...")
+    processed_valid = valid_dataset.map(function=make_map_fn("valid"), with_indices=True)
+    valid_path = os.path.join(output_dir, "valid.parquet")
+    processed_valid.to_parquet(valid_path)
+    print(f"Saved validation set to {valid_path}")
+
+    # Show sample from each set
+    print("\nSample from train set:")
+    pprint(processed_train[0])
+    print("\nSample from validation set:")    pprint(processed_valid[0])
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--output_dir', required=True, help="Output directory for processed parquet")
     parser.add_argument('--valid_ratio', type=float, default=0.1, help="Ratio for validation split (default: 0.1)")
     args = parser.parse_args()
-    
-    print(f"Loading dataset...")
-    # Load from Hugging Face Hub - full dataset
-    dataset = load_dataset("CharlieDreemur/OpenManus-RL", split="train")
-    
-    print(f"Splitting dataset into train/valid with {args.valid_ratio*100}% validation...")
-    # Split into train and validation
-    splits = dataset.train_test_split(test_size=args.valid_ratio, seed=42)
-    train_dataset = splits["train"]
-    valid_dataset = splits["test"]  # The test_split method names the second split "test"
-    
-    print(f"Train set: {len(train_dataset)} examples")
-    print(f"Validation set: {len(valid_dataset)} examples")
-    
-    # Create output directory
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    # Process and save train set
-    print("Processing train set...")
-    processed_train = train_dataset.map(function=make_map_fn("train"), with_indices=True)
-    train_path = os.path.join(args.output_dir, "train.parquet")
-    processed_train.to_parquet(train_path)
-    print(f"Saved train set to {train_path}")
-    
-    # Process and save validation set
-    print("Processing validation set...")
-    processed_valid = valid_dataset.map(function=make_map_fn("valid"), with_indices=True)
-    valid_path = os.path.join(args.output_dir, "valid.parquet")
-    processed_valid.to_parquet(valid_path)
-    print(f"Saved validation set to {valid_path}")
-    
-    # Show sample from each set
-    print("\nSample from train set:")
-    pprint(processed_train[0])
-    print("\nSample from validation set:")
-    pprint(processed_valid[0])
+    main(args.output_dir, args.valid_ratio)

--- a/data/generate_train_agentgym_all.py
+++ b/data/generate_train_agentgym_all.py
@@ -256,9 +256,14 @@ def save_environment_data(train_env_groups, eval_item_ids, train_id_to_sample, o
         else:
             print(f"Warning: No test samples found for environment '{env_name}'")
 
-def main():
-    """
-    Main function to process and save AgentGym datasets by environment.
+def main(output_base_dir: str = './'):
+    """Process AgentGym datasets and save them to ``output_base_dir``.
+
+    Parameters
+    ----------
+    output_base_dir: str, optional
+        Directory to store generated ``train.parquet``, ``val.parquet`` and
+        ``test.parquet`` files for each environment. Default ``./``.
     """
     # Set random seed for reproducibility
     random.seed(42)
@@ -305,9 +310,18 @@ def main():
     
     # Save environment data
     print("\nSaving environment data...")
-    save_environment_data(train_env_groups, eval_env_item_ids, train_id_to_sample, output_base_dir='./')
-    
+    save_environment_data(train_env_groups, eval_env_item_ids, train_id_to_sample, output_base_dir=output_base_dir)
+
     print("Processing complete!")
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--output_dir',
+        default='./',
+        help='Base directory for generated environment datasets'
+    )
+    args = parser.parse_args()
+
+    main(args.output_dir)


### PR DESCRIPTION
## Summary
- update data generation scripts so they can be invoked as modules
- expose a new helper `generate_all_datasets.py` to produce SFT and RL data

## Testing
- `python3 -m py_compile data/generate_all_datasets.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686d4a5a54c48323a6a3a019450702e4